### PR TITLE
Fixed Seg fault err in the redix server

### DIFF
--- a/src/ClientConnection.h
+++ b/src/ClientConnection.h
@@ -18,7 +18,7 @@ private:
   bool write_full(char *buf, ssize_t n);
 public:
   ClientConnection(int sock_fd);
-  bool receive_request(std::string& msg);
+  int receive_request(std::string& msg);
   void send_response(std::string &response);
 };
 

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -9,6 +9,11 @@
 // consider using an unorder_map to map strings to operations
 // consider creating a command class to delegate some of this work to
 std::string RequestHandler::handle_request(const std::string &cmd_str) {
+  if(cmd_str.size() <= 0) {
+    // empty string would cause error
+    return "";
+  }
+
   std::vector<std::string> cmd;
   parse_cmd_from_str(cmd_str, cmd);
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -52,6 +52,10 @@ bool Client::connect_to_server() {
     return true;
 }
 
+void Client::disconnect() {
+    close(this->socket_fd);
+}
+
 // Send a request to the server
 bool Client::send_request(const std::string& req) {
     const char* text = req.c_str();
@@ -108,8 +112,13 @@ std::string Client::read_response() {
 int32_t Client::read_full(int fd, char *buf, size_t n) {
     while (n > 0) {
         int rv = read(fd, buf, n);
-        if(rv <= 0) {
-            // perror("read() in read_full() failed");
+        if(rv < 0) {
+            perror("read() in read_full() failed");
+            return -1;
+        } else if(rv == 0) {
+            std::cerr << "Server disconnected unexpectedly." << std::endl;
+            close(this->socket_fd);
+            this->socket_fd = -1;  // Mark as disconnected
             return -1;
         }
 
@@ -128,8 +137,13 @@ int32_t Client::read_full(int fd, char *buf, size_t n) {
 int32_t Client::write_full(int fd, char *buf, size_t n) {
     while (n > 0) {
         int rv = write(fd, buf, n);
-        if(rv <= 0) {
-            // perror("write() in write_full() failed");
+        if(rv < 0) {
+            perror("write() in write_full() failed");
+            return -1;
+        } else if(rv == 0) {
+            std::cerr << "Server disconnected unexpectedly." << std::endl;
+            close(this->socket_fd);
+            this->socket_fd = -1;  // Mark as disconnected
             return -1;
         }
 

--- a/src/client.h
+++ b/src/client.h
@@ -15,7 +15,7 @@ public:
     ~Client();
 
     bool connect_to_server();
-
+    void disconnect();
     std::string get(const std::string& key);
     std::string set(const std::string& key, const std::string& value);
     std::string del(const std::string& key);

--- a/src/rediXServer.cpp
+++ b/src/rediXServer.cpp
@@ -35,9 +35,7 @@ int main(int argc, char* argv[]) {
 
         if (server.start()) {
             std::cout << "Server running at " << addr << ":" << port << ". Press Ctrl+C to stop." << std::endl;
-            while(!interupted) {
-                
-            }
+            while(!interupted) {}
         } else {
             std::cerr << "Failed to start server" << std::endl;
             return 1;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -133,12 +133,19 @@ void Server::run() {
   while (!this->stop_requested) {
     this->accept_client();
 
-    for (size_t i = 0; i < client_connections.size(); ++i) {
-      ClientConnection* client = client_connections[i];
+    for (auto it = client_connections.begin(); it < client_connections.end(); ++it) {
+      ClientConnection* client = *it;
+
       std::string client_msg;
-      if (client->receive_request(client_msg)) {
+      int read_result = client->receive_request(client_msg);
+      if (read_result == 1) {
         std::string response = request_handler.handle_request(client_msg);
         client->send_response(response);
+      } else if(read_result == -1) {
+        // Connection was closed or an error
+        // destroy the client connection object
+        delete client;
+        it = client_connections.erase(it);
       }
     }
   }


### PR DESCRIPTION
Explanation: caused by recieve_request function in clientconnection class. It was treating the closed socket signal as a cmd string. This cmd str was null, casuing the seg fault.